### PR TITLE
OAuth support via direct access to requests session

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,24 @@ Misc usage
    for record in s.query(table='incident', query={'state': 2}).get_all():
        print(record['number'])
        
+Using OAuth
+-----------
+
+You can use OAuth authentication. In order to do so you'll need to create a
+`Requests <http://docs.python-requests.org/en/master/>`_ session that handles
+OAuth. The easiest way to do this is to use `Requests-OAuthlib <https://requests-oauthlib.readthedocs.io/en/latest/>`_.
+There is a complete example available in the `examples <docs/examples.rst>`_.
+
+.. code-block:: python
+   import pysnow
+
+   oauth_session = ... # create requests session that uses OAuth
+
+   s = pysnow.Client(instance='myinstance',
+		     session=outh_session,
+		     raise_on_empty=True)
+
+
 
 
 See the `documentation <http://pysnow.readthedocs.org/>`_ for more examples and other info

--- a/README.rst
+++ b/README.rst
@@ -163,6 +163,7 @@ OAuth. The easiest way to do this is to use `Requests-OAuthlib <https://requests
 There is a complete example available in the `examples <docs/examples.rst>`_.
 
 .. code-block:: python
+
    import pysnow
 
    oauth_session = ... # create requests session that uses OAuth
@@ -170,9 +171,6 @@ There is a complete example available in the `examples <docs/examples.rst>`_.
    s = pysnow.Client(instance='myinstance',
 		     session=outh_session,
 		     raise_on_empty=True)
-
-
-
 
 See the `documentation <http://pysnow.readthedocs.org/>`_ for more examples and other info
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -99,3 +99,84 @@ Catching server response errors
        print("%s, details: %s" % (e.error_summary, e.error_details))
 
 
+Using OAuth
+-----------
+
+You will need to enable OAuth inside ServiceNow which is beyond the scope of this
+document. You can find the details in the `ServiceNow documentation <https://docs.servicenow.com/bundle/istanbul-servicenow-platform/page/integrate/inbound-rest/task/t_EnableOAuthWithREST.html>`_.
+
+You will need to install
+`Requests-OAuthlib <https://requests-oauthlib.readthedocs.io/en/latest/>`_ in order to
+follow this example.
+
+Initial tokens
+^^^^^^^^^^^^^^
+
+You will need an access_token and a refresh_token. The ServiceNow OAuth documentation
+provides one way to get the initial tokens but here is a simple example of obtaining
+them using Python.
+
+You will need a username and password to obtain the initial access and refresh tokens.
+Once you have these you will not need the username and password again until the
+refresh token expires. This expiration is controlled in your ServiceNow setup.
+
+.. code-block:: python
+
+
+   import json
+   from oauthlib.oauth2 import LegacyApplicationClient
+   from requests_oauthlib import OAuth2Session
+
+   client_id = 'CLIENT_ID'         # from the ServiceNow setup
+   client_secret = 'CLIENT_SECRET' # also from ServiceNow setup
+   username = 'USER_NAME'          # a valid ServiceNow user
+   password = 'USER_PASSWORD'      # a valid ServiceNow password
+   instance = 'SNOW_INSTANCE'      # the name of your ServiceNow instance
+
+   oauth_url = 'https://{}.service-now.com/oauth_token.do'.format(instance)
+
+   oauth = OAuth2Session(client=LegacyApplicationClient(client_id=client_id))
+   token = oauth.fetch_token(token_url=oauth_url,
+                             username=username,
+                             password=password,
+                             client_id=client_id,
+                             client_secret=client_secret)
+
+   print json.dumps(token, indent=4)
+
+Save the contents of the ``token`` dictionary you get back. You'll need that that in
+the following steps.
+
+Using the tokens
+^^^^^^^^^^^^^^^^
+
+You will need the token dictionary created in the above step. This example sets up
+autorefresh of the tokens. This will work for as long as the refresh_token is valid.
+
+.. code-block:: python
+
+   import pysnow
+   from oauthlib.oauth2 import LegacyApplicationClient
+   from requests_oauthlib import OAuth2Session
+
+   client_id = 'CLIENT_ID'         # from the ServiceNow setup
+   client_secret = 'CLIENT_SECRET' # also from ServiceNow setup
+   username = 'USER_NAME'          # a valid ServiceNow user
+
+   oauth_url = 'https://{}.service-now.com/oauth_token.do'.format(instance)
+
+   token = ... # token dict from the previous step
+
+   refresh_kwargs = { "client_id": client_id, "client_secret": client_secret }
+
+   def token_updater(new_token):
+       # callback to update/store the new tokens
+       pass
+
+   oauth_session = OAuth2Session(client=LegacyApplicationClient(client_id=client_id),
+                                 token=token,
+                                 auto_refresh_url=oauth_url,
+                                 auto_refresh_kwargs=refresh_kwargs,
+                                 token_updater=token_updater)
+
+   s = pysnow.client(instance=instance, session=oauth_session, raise_on_empty=True)

--- a/pysnow.py
+++ b/pysnow.py
@@ -248,8 +248,8 @@ class Client(object):
         """Sets configuration and creates a session object used in `Request` later on
 
         You must either provide a username and password or a requests session.
-        If you provide a requests session it must handle the authentication;
-        this can be used to do OAuth authentication, for example.
+        If you provide a requests session it must handle the authentication.
+        For example, providing a session can be used to do OAuth authentication.
 
         :param instance: instance name, used to resolve FQDN in `Request`
         :param user: username

--- a/pysnow.py
+++ b/pysnow.py
@@ -247,6 +247,10 @@ class Client(object):
     def __init__(self, instance, user=None, password=None, raise_on_empty=True, default_payload=None, session=None):
         """Sets configuration and creates a session object used in `Request` later on
 
+        You must either provide a username and password or a requests session.
+        If you provide a requests session it must handle the authentication;
+        this can be used to do OAuth authentication, for example.
+
         :param instance: instance name, used to resolve FQDN in `Request`
         :param user: username
         :param password: password
@@ -256,7 +260,7 @@ class Client(object):
         """
         # Connection properties
 
-        if (not (user and password)) and not session:
+        if ((not (user and password)) and not session) or ((user or password) and session):
             raise InvalidUsage("You must either provide username and password or a session")
 
         self.instance = instance


### PR DESCRIPTION
This pull request changes `Client.__init__` to accept either a username and password or a requests session. This makes it easy to support OAuth using [Requests-OAuthlib](https://requests-oauthlib.readthedocs.io/en/latest/).  There are also documentation updates explaining how to use Requests-OAuthlib with pysnow.  

In order to keep the changes to the pysnow minimal I didn't make Requests-OAuthlib a required dependency, instead applications needing OAuth can add it as a dependency directly and follow the example code.