### PR TITLE
Branch 0.6.4

### DIFF
--- a/pysnow/__init__.py
+++ b/pysnow/__init__.py
@@ -7,4 +7,4 @@ from .query_builder import QueryBuilder
 from .resource import Resource
 
 __author__ = "Robert Wikman <rbw@vault13.org>"
-__version__ = "0.6.3"
+__version__ = "0.6.4"

--- a/pysnow/response.py
+++ b/pysnow/response.py
@@ -92,7 +92,7 @@ class Response(object):
                     builder.event(event, value)
 
         if (has_result_single or has_result_many) and self.count == 0:  # Results empty
-            yield {}
+            raise StopIteration
 
         if not (has_result_single or has_result_many or has_error):  # None of the expected keys were found
             raise MissingResult('The expected `result` key was missing in the response. Cannot continue')
@@ -137,9 +137,9 @@ class Response(object):
             - NoResults: If no results were found
         """
 
-        content = next(self.all())
-
-        if len(content) == 0:
+        try:
+            content = next(self.all())
+        except StopIteration:
             raise NoResults("No records found")
 
         return content
@@ -164,13 +164,14 @@ class Response(object):
 
         :raise:
             - MultipleResults: If more than one records are present in the content
-            - NoResults: If no records are present in the content
+            - NoResults: If the result is empty
         """
 
         r = self.all()
-        result = next(r)
 
-        if len(result) == 0:
+        try:
+            result = next(r)
+        except StopIteration:
             raise NoResults("No records found")
 
         try:

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -217,8 +217,7 @@ class TestResourceRequest(unittest.TestCase):
 
     @httpretty.activate
     def test_get_all_empty(self):
-        """:meth:`all` of :class:`pysnow.Response` should return a list with an empty object if `raise_on_empty`
-        is set to False"""
+        """:meth:`all` generator of :class:`pysnow.Response` should return an empty list if there are no matches"""
 
         httpretty.register_uri(httpretty.GET,
                                self.mock_url_builder_base,
@@ -227,10 +226,9 @@ class TestResourceRequest(unittest.TestCase):
                                content_type="application/json")
 
         response = self.resource.get(self.dict_query)
-        response._raise_on_empty = False
         result = list(response.all())
 
-        self.assertEquals(result[0], {})
+        self.assertEquals(result, [])
 
     @httpretty.activate
     def test_get_one_missing_result_keys(self):


### PR DESCRIPTION
Fixes an issue with empty result set in generator returning a list with an empty dict, and double dicts in some cases as reported in #74