### PR TITLE
Add auto retry on some common errors

### DIFF
--- a/pysnow/client.py
+++ b/pysnow/client.py
@@ -6,6 +6,8 @@ import warnings
 
 import requests
 from requests.auth import HTTPBasicAuth
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 import pysnow
 
@@ -114,6 +116,10 @@ class Client(object):
                 'User-Agent': 'pysnow/%s' % pysnow.__version__
             }
         )
+
+        # set auto retry for about 2 seconds on some common errors
+        s.mount('http://', HTTPAdapter(max_retries=Retry(total=3, backoff_factor=0.3, status_forcelist=(401,408,429,431,500,502,503,504,511))))
+        s.mount('https://', HTTPAdapter(max_retries=Retry(total=3, backoff_factor=0.3, status_forcelist=(401,408,429,431,500,502,503,504,511))))
 
         return s
 


### PR DESCRIPTION
Occasionally I open too many sessions at once at Snow and I get an error message.

The code here will automatically retry on an error for about 2 seconds and then error out as before.  

The big ones for me are 401 and 429.  (My LDAP connections limit and my operations limit).