### PR TITLE
Convert tz-aware datetime to UTC for gt/lt filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.6"
 # command to install dependencies
 install:
-  - pip install pysnow requests httpretty oauthlib requests_oauthlib coverage python-coveralls nose ijson six
+  - pip install pysnow requests httpretty oauthlib requests_oauthlib coverage python-coveralls nose ijson six pytz
 # command to run tests
 script:
   - nosetests --with-coverage --cover-package=pysnow --cover-erase

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with io.open('README.rst') as readme:
         version=get_version(),
         description='Python library for the ServiceNow REST API',
         long_description=readme.read(),
-        install_requires=['requests', 'oauthlib', 'requests_oauthlib', 'httpretty', 'six', 'ijson'],
+        install_requires=['requests', 'oauthlib', 'requests_oauthlib', 'httpretty', 'six', 'ijson', 'pytz'],
         author='Robert Wikman',
         author_email='rbw@vault13.org',
         maintainer='Robert Wikman',

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
+import pytz
 import pysnow
 from datetime import datetime as dt
 
@@ -158,8 +159,13 @@ class TestQueryBuilder(unittest.TestCase):
         q2 = pysnow.QueryBuilder().field('test').greater_than(1)
         self.assertEqual(str(q2), 'test>1')
 
+        # Make sure naive dates are assumed as UTC
         q3 = pysnow.QueryBuilder().field('test').greater_than(dt(2016, 2, 1))
         self.assertEqual(str(q3), 'test>2016-02-01 00:00:00')
+
+        # Make sure tz-aware dates are converted to UTC (UTC+1)
+        q4 = pysnow.QueryBuilder().field('test').greater_than(dt(2016, 2, 1, 3, tzinfo=pytz.FixedOffset(60)))
+        self.assertEqual(str(q4), 'test>2016-02-01 02:00:00')
 
     def test_query_cond_less_than(self):
         # Make sure type checking works
@@ -170,8 +176,13 @@ class TestQueryBuilder(unittest.TestCase):
         q2 = pysnow.QueryBuilder().field('test').less_than(1)
         self.assertEqual(str(q2), 'test<1')
 
+        # Make sure naive dates are assumed as UTC
         q3 = pysnow.QueryBuilder().field('test').less_than(dt(2016, 2, 1))
         self.assertEqual(str(q3), 'test<2016-02-01 00:00:00')
+
+        # Make sure tz-aware dates are converted to UTC (UTC+1)
+        q3 = pysnow.QueryBuilder().field('test').less_than(dt(2016, 2, 1, 3, tzinfo=pytz.FixedOffset(60)))
+        self.assertEqual(str(q3), 'test<2016-02-01 02:00:00')
 
     def test_complex_query(self):
         start = dt(2016, 2, 1)


### PR DESCRIPTION
I found the current behaviour confusing when trying to do this date filtering as per #93. This checks whether a datetime has a timezone configured and if so converts it to UTC time for the comparison in ServiceNow. If it does not have any TZ info attached it assumes it is already UTC time.